### PR TITLE
修复待办项删除错乱及编辑后状态丢失问题

### DIFF
--- a/qml/Todo.qml
+++ b/qml/Todo.qml
@@ -475,8 +475,8 @@ WidgetTemplate {
                             comfirmDialog.open();
                         } else {
                             todoModel.remove(index);
-                            let data = widget.settings.data;
-                            data.pop(index);
+                            let data = widget.settings.data.slice();
+                            data.splice(index, 1);
                             widget.settings.data = data;
                         }
                     }
@@ -514,8 +514,8 @@ WidgetTemplate {
 
         onAccepted: {
             todoModel.remove(index);
-            let data = widget.settings.data;
-            data.pop(index);
+            let data = widget.settings.data.slice();
+            data.splice(index, 1);
             widget.settings.data = data;
         }
     }

--- a/qml/Toset.qml
+++ b/qml/Toset.qml
@@ -84,10 +84,16 @@ NVG.Window {
                 let cfg = rootPreference.save();
                 if (cfg.todo.length > 0) {
                     if (index > -1) {
-                        todoModel.set(index, {"todo": cfg.todo, "priority": cfg.priority});
-                        let _data = widget.settings.data;
-                        _data[index].todo = cfg.todo;
-                        _data[index].priority = cfg.priority;
+                        let currentItem = todoModel.get(index);
+                        let updatedItem = {
+                            "todo": cfg.todo,
+                            "priority": cfg.priority,
+                            "done": currentItem.done,
+                            "createTime": currentItem.createTime
+                        };
+                        todoModel.set(index, updatedItem);
+                        let _data = widget.settings.data.slice();
+                        _data[index] = Object.assign({}, _data[index], updatedItem);
                         widget.settings.data = _data;
                     } else {
                         let _time = new Date();


### PR DESCRIPTION
### 变更说明
这个 PR 主要修复了 TodoWidget 中两个与数据一致性相关的问题：

1. 删除待办项时可能误删其他项
2. 编辑待办项时会丢失部分原有状态

### 具体修复
#### 1. 修复删除错项问题
在 [`qml/Todo.qml`](qml/Todo.qml) 中，原来的删除逻辑使用了 [`pop()`](qml/Todo.qml:479)，但这个方法只会移除数组最后一个元素，传入的索引参数不会生效。

这会导致：
- 界面上删除的是当前点击的任务
- 但持久化数据里删除的却是最后一条任务
- 重新加载后就会出现“删错项”的情况

现在已改为使用 [`splice(index, 1)`](qml/Todo.qml:479) 按实际索引删除，保证界面数据和持久化数据保持一致。

同时也修复了确认删除对话框中的同类问题，位置在 [`qml/Todo.qml`](qml/Todo.qml:515)。

#### 2. 修复编辑后状态丢失问题
在 [`qml/Toset.qml`](qml/Toset.qml:83) 中，编辑已有任务时，原逻辑只更新了 `todo` 和 `priority`，没有保留原有的 `done` 和 `createTime`。

这会导致：
- 编辑后任务完成状态可能异常
- 原始创建时间丢失
- 排序结果可能受到影响

现在编辑时会先读取当前项，再保留原有的 [`done`](qml/Toset.qml:91) 和 [`createTime`](qml/Toset.qml:92)，只更新实际需要修改的字段。

### 影响结果
修复后：
- 删除任意任务时，不会再误删其他任务
- 删除后的持久化数据与界面显示一致
- 编辑任务后，完成状态不会丢失
- 编辑任务后，排序依据仍然保持正确

### 手动测试
已进行手动测试：
- 连续创建多条任务
- 删除中间项与末尾项
- 在不同筛选视图下删除任务
- 编辑已有任务的内容与优先级
- 重新打开组件后确认数据仍然正确

### 备注
这次修改只涉及 [`qml/Todo.qml`](qml/Todo.qml) 和 [`qml/Toset.qml`](qml/Toset.qml)，属于一次较小且范围集中的 bugfix，不会改变原有功能设计。
